### PR TITLE
🔧 feat: Update github repo link

### DIFF
--- a/client/app-shell.jsx
+++ b/client/app-shell.jsx
@@ -53,7 +53,7 @@ const ApplicationShell = () => {
 
                     {/* Always visible links */}
                     <a
-                        href="https://github.com/HemmeligOrg/Hemmelig.app"
+                        href="https://github.com/nine-digital/service-onetimesecret"
                         rel="noreferrer"
                         className="text-xs text-gray-400 hover:text-gray-200 uppercase transition-colors"
                     >

--- a/package.json
+++ b/package.json
@@ -57,12 +57,12 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/nerajchand/Hemmelig.git"
+    "url": "git+https://github.com/nine-digital/service-onetimesecret.git"
   },
   "author": "Bjarne Øverli",
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/HemmeligOrg/Hemmelig.app/issues"
+    "url": "https://github.com/nine-digital/service-onetimesecret/issues"
   },
   "homepage": "/",
   "dependencies": {


### PR DESCRIPTION
Updating the Github Repo link that is located in the footer to the Nine Digital Repository.