### PR TITLE
fix: Update Docker setup for PostgreSQL connectivity

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,8 @@
+version: '3.8'
+
 services:
     hemmelig:
-        image: ghcr.io/nerajchand/hemmelig:latest
+        image: ghcr.io/nerajchand/hemmelig:1.5.0
         hostname: hemmelig
         init: true
         volumes:
@@ -24,9 +26,10 @@ services:
         restart: always
         stop_grace_period: 1m
         healthcheck:
-            test: 'curl -o /dev/null localhost:3000/api/healthz || exit 1'
-            timeout: 5s
-            retries: 3
+            test: ['CMD', 'curl', '-f', 'http://localhost:3000/api/healthz']
+            interval: 30s
+            timeout: 10s
+            retries: 5
         depends_on:
             - postgres
     postgres:
@@ -40,6 +43,7 @@ services:
             - postgres_data:/var/lib/postgresql/data
         ports:
             - '5432:5432'
+
 volumes:
     postgres_data:
         driver: local

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,9 +1,22 @@
 #!/bin/sh
 set -e
 
+# Function to wait for PostgreSQL to become available
+wait_for_postgres() {
+    echo "Waiting for PostgreSQL to be available..."
+    until nc -z postgres 5432; do
+        sleep 1
+    done
+    echo "PostgreSQL is available!"
+}
+
+# Wait for the PostgreSQL service
+wait_for_postgres
+
 # Run Prisma migrations
 echo "Running Prisma migrations..."
 npx prisma migrate deploy
 
+# Start the main application
 echo "Starting main app: $@"
 exec "$@"


### PR DESCRIPTION
- Fix Dockerfile to explicitly install netcat-openbsd to resolve build issues.
- Modify docker-compose.yml to ensure service dependencies are correctly managed.
- Update docker-entrypoint.sh to wait for PostgreSQL to be available before running migrations and starting the application.