### PR TITLE
feat: Hide decryption key in the URL

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -29,15 +29,15 @@ const cli = meow(
 
 	Examples
       $ hemmelig "my super secret" --password=1337
-      [*] Hemmelig.app URL: https://hemmelig.app/secret/thesecretid#encryption_key=myencryptionkey
+      [*] Hemmelig.app URL: https://hemmelig.app/secret/thesecretid#bXllbmNyeXB0aW9ua2V5
 
       # Pipe data to the hemmelig cli
       $ cat mysecret.txt | hemmelig
-      [*] Hemmelig.app URL: https://hemmelig.app/secret/thesecretid2#encryption_key=myencryptionkey2
+      [*] Hemmelig.app URL: https://hemmelig.app/secret/thesecretid2#bXllbmNyeXB0aW9ua2V5Mg==
 
       # Different output
       $ hemmelig "I am secret" -o=json
-      {"encryptionKey":"9LiWq3iMAF0IkQs1tecOxbYKFesEnTN9","secretId":"manageable_CEsgWtxEaNNbwld6PjwyF1bQaiy4jQl9","url":"https://hemmelig.app/secret/manageable_CEsgWtxEaNNbwld6PjwyF1bQaiy4jQl9#encryption_key=9LiWq3iMAF0IkQs1tecOxbYKFesEnTN9"}
+      {"encryptionKey":"9LiWq3iMAF0IkQs1tecOxbYKFesEnTN9","secretId":"manageable_CEsgWtxEaNNbwld6PjwyF1bQaiy4jQl9","url":"https://hemmelig.app/secret/manageable_CEsgWtxEaNNbwld6PjwyF1bQaiy4jQl9#OUxpV3EzaU1BRjBJa1FzMXRlY094YllLRmVzRW5UTjk="}
 `,
     {
         importMeta: { url },
@@ -109,7 +109,7 @@ const createSecret = async (data = {}) => {
 };
 
 const getSecretURL = (encryptionKey, secretId) =>
-    `${cli.flags.url}/secret/${secretId}#encryption_key=${encryptionKey}`;
+    `${cli.flags.url}/secret/${secretId}#${Buffer.from(encryptionKey).toString('base64')}`;
 
 const createOutput = (encryptionKey, secretId) => {
     const url = getSecretURL(encryptionKey, secretId);

--- a/client/routes.jsx
+++ b/client/routes.jsx
@@ -34,7 +34,6 @@ const createAppRouter = () => {
             <>
                 <Route path="/" element={<ApplicationShell />}>
                     <Route index element={<Home />} />
-                    <Route path="secret/:encryptionKey/:secretId" element={<Secret />} />
                     <Route path="secret/:secretId" element={<Secret />} />
                     <Route
                         element={<PublicSecrets />}

--- a/client/routes/home/index.jsx
+++ b/client/routes/home/index.jsx
@@ -18,7 +18,6 @@ import {
 } from '@tabler/icons-react';
 import { useCallback, useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { Link } from 'react-router-dom';
 import { burnSecret } from '../../api/secret';
 import CopyButton from '../../components/CopyButton';
 import Editor from '../../components/editor';
@@ -94,7 +93,7 @@ const Home = () => {
 
     const getSecretURL = (withEncryptionKey = true) => {
         if (!withEncryptionKey) return `${window.location.origin}/secret/${secretId}`;
-        return `${window.location.origin}/secret/${secretId}#encryption_key=${encryptionKey}`;
+        return `${window.location.origin}/secret/${secretId}#${btoa(encryptionKey)}`;
     };
 
     const onShare = (event) => {
@@ -767,7 +766,6 @@ const Home = () => {
                     </FormSection>
                 </>
             )}
-
         </div>
     );
 };

--- a/client/routes/public/index.jsx
+++ b/client/routes/public/index.jsx
@@ -42,7 +42,7 @@ const PublicSecrets = () => {
                             <tr key={secret.id} className="hover:bg-gray-700/30 transition-colors">
                                 <td className="px-6 py-4 whitespace-nowrap">
                                     <Link
-                                        to={`/secret/${secret.id}#encryption_key=public`}
+                                        to={`/secret/${secret.id}#${btoa('public')}`}
                                         className="text-gray-300 hover:text-white transition-colors"
                                     >
                                         {(secret.title.length > 40

--- a/client/routes/secret/index.jsx
+++ b/client/routes/secret/index.jsx
@@ -18,10 +18,12 @@ import Editor from '../../components/editor';
 import ErrorBox from '../../components/error-box';
 
 const getEncryptionKeyHash = (hash) => {
-    const id = '#encryption_key=';
-    if (!hash || !hash.includes(id)) return '';
-    const [_, encryptionKey] = hash.split('#encryption_key=');
-    return encryptionKey;
+    if (!hash) return '';
+    try {
+        return atob(hash.substring(1));
+    } catch (e) {
+        return '';
+    }
 };
 
 const Secret = () => {


### PR DESCRIPTION
This change will modify the URL that is generated when creating a one time secret. 
Previously you would see the URL with the decryption key displayed in plain text. Now this will encode that and hide it from plain sight. 
