### PR TITLE
fix: Hide Password by default in API response

### DIFF
--- a/client/routes/api-docs/index.jsx
+++ b/client/routes/api-docs/index.jsx
@@ -369,6 +369,7 @@ const ApiDocs = () => {
                                                 ttl: 86400,
                                                 maxViews: 1,
                                                 title: 'Generated Password',
+                                                showPassword: false,
                                             },
                                             null,
                                             2
@@ -377,9 +378,34 @@ const ApiDocs = () => {
                                 </pre>
                                 <p className="text-gray-400 text-xs mt-2">
                                     All fields are optional. Defaults: length=16, all character sets
-                                    enabled, ttl=86400 (1 day), maxViews=1.
+                                    enabled, ttl=86400 (1 day), maxViews=1, showPassword=false.
                                 </p>
-                                <p className="text-gray-400 text-xs mt-2">Example response:</p>
+                                <p className="text-gray-400 text-xs mt-2">
+                                    Note: By default, the password is not returned in the response
+                                    for security. Set{' '}
+                                    <code className="text-gray-300">showPassword: true</code> to
+                                    include it.
+                                </p>
+                                <p className="text-gray-400 text-xs mt-2">
+                                    Example response (default, no password):
+                                </p>
+                                <pre className="bg-gray-900/50 p-3 rounded-md text-gray-300 overflow-x-auto">
+                                    <code>
+                                        {JSON.stringify(
+                                            {
+                                                url: 'https://secret.local/secret/abc123#encryptionkey',
+                                                secretId: 'abc123',
+                                                expiresAt: '2024-01-02T00:00:00.000Z',
+                                            },
+                                            null,
+                                            2
+                                        )}
+                                    </code>
+                                </pre>
+                                <p className="text-gray-400 text-xs mt-2">
+                                    Example response (with{' '}
+                                    <code className="text-gray-300">showPassword: true</code>):
+                                </p>
                                 <pre className="bg-gray-900/50 p-3 rounded-md text-gray-300 overflow-x-auto">
                                     <code>
                                         {JSON.stringify(
@@ -411,12 +437,15 @@ const ApiDocs = () => {
                                 </p>
                                 <pre className="bg-gray-900/50 p-3 rounded-md text-gray-300 overflow-x-auto">
                                     <code>
-                                        {`GET /api/password/generate?length=20&numbers=true&symbols=true&ttl=3600&maxViews=1`}
+                                        {`GET /api/password/generate?length=20&numbers=true&symbols=true&ttl=3600&maxViews=1&showPassword=false`}
                                     </code>
                                 </pre>
                                 <p className="text-gray-400 text-xs mt-2">
                                     The returned URL can be shared with anyone to retrieve the
-                                    password through the web app.
+                                    password through the web app. By default, the password is not
+                                    included in the response. Add{' '}
+                                    <code className="text-gray-300">showPassword=true</code> to
+                                    include it.
                                 </p>
                             </div>
                         </div>

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3.8'
 
 services:
     hemmelig:
-        image: ghcr.io/nerajchand/hemmelig:1.5.0
+        image: ghcr.io/nerajchand/hemmelig:1.6.1
         hostname: hemmelig
         init: true
         volumes:

--- a/server/controllers/password.js
+++ b/server/controllers/password.js
@@ -93,6 +93,10 @@ async function password(fastify) {
                             type: 'string',
                             maxLength: 255,
                         },
+                        showPassword: {
+                            type: 'boolean',
+                            default: false,
+                        },
                     },
                 },
             },
@@ -109,6 +113,7 @@ async function password(fastify) {
                 ttl = 86400,
                 maxViews = 1,
                 title,
+                showPassword = false,
             } = request.body;
 
             // Validate that at least one character set is enabled
@@ -203,12 +208,18 @@ async function password(fastify) {
                 const encryptionKeyBase64 = Buffer.from(encryptionKey).toString('base64');
                 const shareableUrl = `${baseUrl}/secret/${secret.id}#${encryptionKeyBase64}`;
 
-                return reply.code(200).send({
+                const response = {
                     url: shareableUrl,
                     secretId: secret.id,
-                    password: generatedPassword, // Return for convenience
                     expiresAt: secret.expiresAt,
-                });
+                };
+
+                // Only include password if explicitly requested (POST uses boolean)
+                if (showPassword) {
+                    response.password = generatedPassword;
+                }
+
+                return reply.code(200).send(response);
             } catch (error) {
                 fastify.log.error(error);
                 return reply.code(500).send({
@@ -276,6 +287,10 @@ async function password(fastify) {
                             type: 'string',
                             pattern: '^\\d+$',
                         },
+                        showPassword: {
+                            type: 'string',
+                            enum: ['true', 'false'],
+                        },
                     },
                 },
             },
@@ -291,6 +306,7 @@ async function password(fastify) {
                 strict = 'false',
                 ttl = '86400',
                 maxViews = '1',
+                showPassword = 'false',
             } = request.query;
 
             const lengthNum = parseInt(length, 10);
@@ -397,12 +413,18 @@ async function password(fastify) {
                 const encryptionKeyBase64 = Buffer.from(encryptionKey).toString('base64');
                 const shareableUrl = `${baseUrl}/secret/${secret.id}#${encryptionKeyBase64}`;
 
-                return reply.code(200).send({
+                const response = {
                     url: shareableUrl,
                     secretId: secret.id,
-                    password: generatedPassword, // Return for convenience
                     expiresAt: secret.expiresAt,
-                });
+                };
+
+                // Only include password if explicitly requested
+                if (showPassword === 'true') {
+                    response.password = generatedPassword;
+                }
+
+                return reply.code(200).send(response);
             } catch (error) {
                 fastify.log.error(error);
                 return reply.code(500).send({


### PR DESCRIPTION
Previously when generating a password using the API it would show the generated password in plain text in the response. This is now hidden by default, however if needed it can still be shown with `showPassword: true`