### PR TITLE
feat: add environment variables for instance settings configuration

### DIFF
--- a/config/default.cjs
+++ b/config/default.cjs
@@ -24,6 +24,17 @@ const {
     SECRET_RATE_LIMIT_TIME_WINDOW = 60,
     SECRET_ANALYTICS_ENABLED = 'true',
     SECRET_ANALYTICS_HMAC_SECRET = '1234567890',
+    // Instance settings defaults
+    SECRET_READ_ONLY = 'false',
+    SECRET_DISABLE_USERS = 'false',
+    SECRET_DISABLE_USER_ACCOUNT_CREATION = 'false',
+    SECRET_DISABLE_IP_RESTRICTION = 'false',
+    SECRET_DISABLE_FILE_UPLOAD = 'false',
+    SECRET_RESTRICT_ORGANIZATION_EMAIL = '',
+    // Secret settings
+    SECRET_MAX_VIEWS_LIMIT = '100',
+    SECRET_ENABLE_BURN_AFTER_TIME = 'true',
+    SECRET_DISABLE_PUBLIC_SECRETS = 'false',
     NODE_ENV = 'development',
 } = process.env;
 
@@ -84,6 +95,21 @@ const config = {
         enabled: JSON.parse(SECRET_ANALYTICS_ENABLED),
         hmacSecret: SECRET_ANALYTICS_HMAC_SECRET,
     },
+    // Instance settings
+    instance: {
+        readOnly: JSON.parse(SECRET_READ_ONLY),
+        disableUsers: JSON.parse(SECRET_DISABLE_USERS),
+        disableUserAccountCreation: JSON.parse(SECRET_DISABLE_USER_ACCOUNT_CREATION),
+        disableIpRestriction: JSON.parse(SECRET_DISABLE_IP_RESTRICTION),
+        disableFileUpload: JSON.parse(SECRET_DISABLE_FILE_UPLOAD),
+        restrictOrganizationEmail: SECRET_RESTRICT_ORGANIZATION_EMAIL,
+    },
+    // Secret settings
+    secret: {
+        maxViewsLimit: Number(SECRET_MAX_VIEWS_LIMIT),
+        enableBurnAfterTime: JSON.parse(SECRET_ENABLE_BURN_AFTER_TIME),
+        disablePublicSecrets: JSON.parse(SECRET_DISABLE_PUBLIC_SECRETS),
+    },
     logger: true,
     cors: '*',
     __client_config: {
@@ -96,6 +122,11 @@ const config = {
             analytics: {
                 enabled: JSON.parse(SECRET_ANALYTICS_ENABLED),
             },
+        },
+        secret: {
+            maxViewsLimit: Number(SECRET_MAX_VIEWS_LIMIT),
+            enableBurnAfterTime: JSON.parse(SECRET_ENABLE_BURN_AFTER_TIME),
+            disablePublicSecrets: JSON.parse(SECRET_DISABLE_PUBLIC_SECRETS),
         },
     },
 };


### PR DESCRIPTION
Added the ability to set configuration options via environment variables. This will allow standard deployment procedures across environments as required.

- Add `SECRET_READ_ONLY`, `SECRET_DISABLE_USERS`, `SECRET_DISABLE_USER_ACCOUNT_CREATION`
- Add `SECRET_DISABLE_IP_RESTRICTION`, `SECRET_DISABLE_FILE_UPLOAD`
- Add `SECRET_RESTRICT_ORGANIZATION_EMAIL` with comma-separated domain support
- Update bootstrap to read and apply instance settings from environment variables
- Update settings API to support comma-separated email domains
- Update email restriction handler to validate against multiple domains