### PR TITLE
fix: fix analytics endpoint and enhance password API

### DIFF
--- a/client/api/analytics.js
+++ b/client/api/analytics.js
@@ -18,6 +18,8 @@ const getAnalyticsData = async () => {
     try {
         const response = await fetch('/api/analytics/data/aggregate/daily', {
             method: 'GET',
+            credentials: 'include',
+            cache: 'no-cache',
             headers: {
                 'Content-Type': 'application/json',
             },
@@ -45,6 +47,8 @@ const getStatistics = async () => {
     try {
         const response = await fetch('/api/stats', {
             method: 'GET',
+            credentials: 'include',
+            cache: 'no-cache',
             headers: {
                 'Content-Type': 'application/json',
             },

--- a/server/controllers/analytics.js
+++ b/server/controllers/analytics.js
@@ -181,12 +181,12 @@ async function analytics(fastify) {
 
                 const rawData = await prisma.$queryRaw`
                     SELECT 
-                        strftime('%Y-%m-%d', "timestamp" / 1000, 'unixepoch') as date,
+                        TO_CHAR("timestamp", 'YYYY-MM-DD') as date,
                         COUNT(DISTINCT "uniqueId") as unique_visitors,
                         COUNT(*) as total_visits,
-                        GROUP_CONCAT(DISTINCT path) as paths
+                        STRING_AGG(DISTINCT path, ', ') as paths
                     FROM "VisitorAnalytics"
-                    GROUP BY strftime('%Y-%m-%d', "timestamp" / 1000, 'unixepoch')
+                    GROUP BY TO_CHAR("timestamp", 'YYYY-MM-DD')
                     ORDER BY date DESC
                     LIMIT 30
                 `;


### PR DESCRIPTION
- Fix analytics SQL query for PostgreSQL compatibility (replace SQLite functions)
- Add credentials: 'include' to analytics API calls for authentication
- Format password API expiresAt timestamps in Australia/Sydney timezone
- Add preventBurn parameter support to password generation API endpoints
- Update maxViews validation to use configurable limit instead of hardcoded 999