### PR TITLE
feat: add environment variable configuration for instance and secret settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -258,33 +258,42 @@ curl "https://your-instance.com/api/password/generate?length=20&numbers=true&sym
 
 ## Environment variables
 
-| ENV vars                        | Description                                                           | Default              |
-| --------------------------------|:---------------------------------------------------------------------:| --------------------:|
-| `SECRET_LOCAL_HOSTNAME`         | The local hostname for the fastify instance                           | 0.0.0.0              |
-| `SECRET_PORT`                   | The port number for the fastify instance                              | 3000                 |
-| `SECRET_HOST`                   | Used for i.e. set cors/cookies to your domain name                    | ""                   |
-| `SECRET_MAX_TEXT_SIZE`          | The max text size for the secret. Is set in kb. i.e. 256 for 256kb.   | 256                  |
-| `SECRET_JWT_SECRET`             | Override this for the secret signin JWT tokens for log in             | good_luck_have_fun   |
-| `SECRET_ROOT_USER`              | Override this for the root account username                           | groot                |
-| `SECRET_ROOT_PASSWORD`          | This is the root password, override it with your own password         | iamgroot             |
-| `SECRET_ROOT_EMAIL`             | This is the root email, override it with your own email               | <groot@hemmelig.app> |
-| `SECRET_FILE_SIZE`              | Set the total allowed upload file size in mb.                         | 4                    |
-| `SECRET_FORCED_LANGUAGE`        | Set the default language for the application.                         | en                   |
-| `SECRET_UPLOAD_RESTRICTION`     | Set the restriction for uploads to signed in users                    | "true"               |
-| `SECRET_RATE_LIMIT_MAX`         | The maximum allowed requests each time frame                          | 1000                 |
-| `SECRET_RATE_LIMIT_TIME_WINDOW` | The time window for the requests before being rate limited in seconds | 60                   |
-| `SECRET_DO_SPACES_ENDPOINT`     | The Digital Ocean Spaces/AWS s3 endpoint                              | ""                   |
-| `SECRET_DO_SPACES_KEY`          | The Digital Ocean Spaces/AWS s3 key                                   | ""                   |
-| `SECRET_DO_SPACES_SECRET`       | The Digital Ocean Spaces/AWS s3 secret                                | ""                   |
-| `SECRET_DO_SPACES_BUCKET`       | The Digital Ocean Spaces/AWS s3 bucket name                           | ""                   |
-| `SECRET_DO_SPACES_FOLDER`       | The Digital Ocean Spaces/AWS s3 folder for the uploaded files         | ""                   |
-| `SECRET_AWS_S3_REGION`          | The Digital AWS s3 region                                             | ""                   |
-| `SECRET_AWS_S3_KEY`             | The Digital AWS s3 key                                                | ""                   |
-| `SECRET_AWS_S3_SECRET`          | The Digital AWS s3 secret                                             | ""                   |
-| `SECRET_AWS_S3_BUCKET`          | The Digital AWS s3 bucket name                                        | ""                   |
-| `SECRET_AWS_S3_FOLDER`          | The Digital AWS s3 folder for the uploaded files                      | ""                   |
-| `SECRET_ANALYTICS_ENABLED`      | Enable analytics tracking                                             | "false"              |
-| `SECRET_ANALYTICS_HMAC_SECRET`  | The HMAC secret for the analytics tracking                            | "1234567890"         |
+| ENV Variable                         | Description                                                  | Default              |
+|---------------------------------------|--------------------------------------------------------------|----------------------|
+| `SECRET_LOCAL_HOSTNAME`               | Local hostname for the Fastify instance                      | `0.0.0.0`            |
+| `SECRET_PORT`                         | Port number for the Fastify instance                         | `3000`               |
+| `SECRET_HOST`                         | Domain for CORS/cookies settings                             | `""`                 |
+| `SECRET_MAX_TEXT_SIZE`                | Max secret text size in KB (e.g., 256 for 256 KB)            | `256`                |
+| `SECRET_JWT_SECRET`                   | JWT signing secret for authentication                        | `good_luck_have_fun` |
+| `SECRET_ROOT_USER`                    | Root account username                                        | `groot`              |
+| `SECRET_ROOT_PASSWORD`                | Root account password                                        | `iamgroot`           |
+| `SECRET_ROOT_EMAIL`                   | Root account email                                           | `groot@hemmelig.app` |
+| `SECRET_FILE_SIZE`                    | Max upload file size (in MB)                                 | `4`                  |
+| `SECRET_FORCED_LANGUAGE`              | Default language for the application                         | `en`                 |
+| `SECRET_UPLOAD_RESTRICTION`           | Restrict uploads to signed-in users ("true"/"false")         | `"true"`             |
+| `SECRET_RATE_LIMIT_MAX`               | Max requests per rate limit window                           | `1000`               |
+| `SECRET_RATE_LIMIT_TIME_WINDOW`       | Rate limit time window (seconds)                             | `60`                 |
+| `SECRET_DO_SPACES_ENDPOINT`           | DigitalOcean Spaces/S3 endpoint                              | `""`                 |
+| `SECRET_DO_SPACES_KEY`                | DigitalOcean Spaces/S3 access key                            | `""`                 |
+| `SECRET_DO_SPACES_SECRET`             | DigitalOcean Spaces/S3 secret key                            | `""`                 |
+| `SECRET_DO_SPACES_BUCKET`             | DigitalOcean Spaces/S3 bucket name                           | `""`                 |
+| `SECRET_DO_SPACES_FOLDER`             | DigitalOcean Spaces/S3 folder for uploads                    | `""`                 |
+| `SECRET_AWS_S3_REGION`                | AWS S3 region                                                | `""`                 |
+| `SECRET_AWS_S3_KEY`                   | AWS S3 access key                                            | `""`                 |
+| `SECRET_AWS_S3_SECRET`                | AWS S3 secret key                                            | `""`                 |
+| `SECRET_AWS_S3_BUCKET`                | AWS S3 bucket name                                           | `""`                 |
+| `SECRET_AWS_S3_FOLDER`                | AWS S3 folder for uploads                                    | `""`                 |
+| `SECRET_ANALYTICS_ENABLED`            | Enable analytics tracking ("true"/"false")                   | `"false"`            |
+| `SECRET_ANALYTICS_HMAC_SECRET`        | HMAC secret for analytics tracking                           | `"1234567890"`       |
+| `SECRET_READ_ONLY`                    | Read-only mode (only admin/creator can create secrets)       | `"false"`            |
+| `SECRET_DISABLE_USERS`                | Disable user functionality                                   | `"false"`            |
+| `SECRET_DISABLE_USER_ACCOUNT_CREATION`| Disable user account registration                            | `"false"`            |
+| `SECRET_DISABLE_IP_RESTRICTION`       | Disable IP restriction feature                               | `"false"`            |
+| `SECRET_DISABLE_FILE_UPLOAD`          | Disable file upload functionality                            | `"false"`            |
+| `SECRET_RESTRICT_ORGANIZATION_EMAIL`  | Allowed email domains for registration (comma-separated)     | `""`                 |
+| `SECRET_MAX_VIEWS_LIMIT`              | Max views per secret                                         | `"100"`              |
+| `SECRET_ENABLE_BURN_AFTER_TIME`       | Enable "burn after expiration" (secrets deleted on max views only) | `"true"`             |
+| `SECRET_DISABLE_PUBLIC_SECRETS`       | Disable public secrets feature                               | `"false"`            |
 
 ## Supported languages
 

--- a/client/api/analytics.js
+++ b/client/api/analytics.js
@@ -18,6 +18,8 @@ const getAnalyticsData = async () => {
     try {
         const response = await fetch('/api/analytics/data/aggregate/daily', {
             method: 'GET',
+            credentials: 'include',
+            cache: 'no-cache',
             headers: {
                 'Content-Type': 'application/json',
             },
@@ -45,6 +47,8 @@ const getStatistics = async () => {
     try {
         const response = await fetch('/api/stats', {
             method: 'GET',
+            credentials: 'include',
+            cache: 'no-cache',
             headers: {
                 'Content-Type': 'application/json',
             },

--- a/client/components/header/nav.jsx
+++ b/client/components/header/nav.jsx
@@ -58,11 +58,14 @@ const Nav = ({ opened, toggle, isLoggedIn }) => {
         });
     }
 
-    navItems.push({
-        label: t('public_list'),
-        icon: <IconList size="1rem" stroke={1.5} />,
-        to: '/public',
-    });
+    // Only show public list if public secrets are enabled
+    if (!settings.disable_public_secrets) {
+        navItems.push({
+            label: t('public_list'),
+            icon: <IconList size="1rem" stroke={1.5} />,
+            to: '/public',
+        });
+    }
 
     if (!opened) {
         return null;

--- a/client/routes/home/index.jsx
+++ b/client/routes/home/index.jsx
@@ -86,6 +86,11 @@ const Home = () => {
     const onSetPublic = (event) => {
         event.preventDefault();
 
+        // Don't allow toggling if public secrets are disabled
+        if (settings.disable_public_secrets) {
+            return;
+        }
+
         setField('isPublic', !isPublic);
     };
 
@@ -338,34 +343,40 @@ const Home = () => {
             <FormSection title={t('home.security')} subtitle={t('home.security_description')}>
                 <div className="grid grid-cols-1 md:grid-cols-2 gap-8">
                     <div className="space-y-6">
-                        <div className="space-y-4">
-                            <button
-                                type="button"
-                                onClick={onSetPublic}
-                                disabled={inputReadOnly}
-                                className={`
-                                        w-full flex items-start gap-4 px-4 py-3.5
-                                        bg-black/20 rounded-lg border
-                                        ${inputReadOnly ? 'cursor-not-allowed opacity-80' : 'hover:border-white/[0.12]'} 
-                                        transition-all duration-200
-                                        ${!isPublic ? 'text-primary border-primary/50' : 'text-gray-300 border-white/[0.08]'}
-                                    `}
-                            >
-                                <div className="p-2.5 bg-black/20 rounded-lg shrink-0">
-                                    {isPublic ? <IconLockOpen size={22} /> : <IconLock size={22} />}
-                                </div>
-                                <div className="flex flex-col items-start min-w-0">
-                                    <span className="text-sm font-medium mb-0.5">
-                                        {t(isPublic ? 'home.public' : 'home.private')}
-                                    </span>
-                                    <span className="text-xs text-gray-400 text-left">
-                                        {isPublic
-                                            ? t('home.public_description')
-                                            : t('home.private_description')}
-                                    </span>
-                                </div>
-                            </button>
-                        </div>
+                        {!settings.disable_public_secrets && (
+                            <div className="space-y-4">
+                                <button
+                                    type="button"
+                                    onClick={onSetPublic}
+                                    disabled={inputReadOnly}
+                                    className={`
+                                            w-full flex items-start gap-4 px-4 py-3.5
+                                            bg-black/20 rounded-lg border
+                                            ${inputReadOnly ? 'cursor-not-allowed opacity-80' : 'hover:border-white/[0.12]'} 
+                                            transition-all duration-200
+                                            ${!isPublic ? 'text-primary border-primary/50' : 'text-gray-300 border-white/[0.08]'}
+                                        `}
+                                >
+                                    <div className="p-2.5 bg-black/20 rounded-lg shrink-0">
+                                        {isPublic ? (
+                                            <IconLockOpen size={22} />
+                                        ) : (
+                                            <IconLock size={22} />
+                                        )}
+                                    </div>
+                                    <div className="flex flex-col items-start min-w-0">
+                                        <span className="text-sm font-medium mb-0.5">
+                                            {t(isPublic ? 'home.public' : 'home.private')}
+                                        </span>
+                                        <span className="text-xs text-gray-400 text-left">
+                                            {isPublic
+                                                ? t('home.public_description')
+                                                : t('home.private_description')}
+                                        </span>
+                                    </div>
+                                </button>
+                            </div>
+                        )}
 
                         <div className="space-y-4">
                             <div
@@ -563,7 +574,7 @@ const Home = () => {
                                 <input
                                     type="range"
                                     min="1"
-                                    max="100"
+                                    max={Math.min(100, config.get('secret.maxViewsLimit'))}
                                     value={formData.maxViews}
                                     onChange={(e) =>
                                         setField('formData.maxViews', parseInt(e.target.value))
@@ -576,34 +587,36 @@ const Home = () => {
                             </div>
                         )}
 
-                        <div className="p-4 bg-black/20 rounded-lg border border-white/[0.08]">
-                            <div
-                                className={`flex items-center justify-between gap-4 ${inputReadOnly ? 'cursor-not-allowed opacity-80' : ''}`}
-                            >
-                                <div className="flex items-center gap-3">
-                                    <div className="p-2 bg-orange-500/10 rounded-lg">
-                                        <IconFlame className="text-orange-400" size={18} />
-                                    </div>
-                                    <div>
-                                        <div className="text-sm font-medium text-white/90">
-                                            {t('home.burn_after_time')}
-                                        </div>
-                                        <div className="text-xs text-gray-400">
-                                            {t('home.burn_aftertime')}
-                                        </div>
-                                    </div>
-                                </div>
-                                <Switch
-                                    checked={formData.preventBurn}
-                                    onChange={(checked) =>
-                                        setField('formData.preventBurn', checked)
-                                    }
-                                    disabled={inputReadOnly}
+                        {config.get('secret.enableBurnAfterTime') && (
+                            <div className="p-4 bg-black/20 rounded-lg border border-white/[0.08]">
+                                <div
+                                    className={`flex items-center justify-between gap-4 ${inputReadOnly ? 'cursor-not-allowed opacity-80' : ''}`}
                                 >
-                                    {t('home.burn_after_time')}
-                                </Switch>
+                                    <div className="flex items-center gap-3">
+                                        <div className="p-2 bg-orange-500/10 rounded-lg">
+                                            <IconFlame className="text-orange-400" size={18} />
+                                        </div>
+                                        <div>
+                                            <div className="text-sm font-medium text-white/90">
+                                                {t('home.burn_after_time')}
+                                            </div>
+                                            <div className="text-xs text-gray-400">
+                                                {t('home.burn_aftertime')}
+                                            </div>
+                                        </div>
+                                    </div>
+                                    <Switch
+                                        checked={formData.preventBurn}
+                                        onChange={(checked) =>
+                                            setField('formData.preventBurn', checked)
+                                        }
+                                        disabled={inputReadOnly}
+                                    >
+                                        {t('home.burn_after_time')}
+                                    </Switch>
+                                </div>
                             </div>
-                        </div>
+                        )}
                     </div>
                 </div>
             </FormSection>

--- a/client/stores/settingsStore.js
+++ b/client/stores/settingsStore.js
@@ -8,6 +8,7 @@ const useSettingsStore = create((set) => ({
         disable_file_upload: false,
         restrict_organization_email: '',
         hide_allowed_ip_input: true,
+        disable_public_secrets: false,
     },
     isLoading: true,
     error: null,

--- a/config/default.cjs
+++ b/config/default.cjs
@@ -24,6 +24,17 @@ const {
     SECRET_RATE_LIMIT_TIME_WINDOW = 60,
     SECRET_ANALYTICS_ENABLED = 'true',
     SECRET_ANALYTICS_HMAC_SECRET = '1234567890',
+    // Instance settings defaults
+    SECRET_READ_ONLY = 'false',
+    SECRET_DISABLE_USERS = 'false',
+    SECRET_DISABLE_USER_ACCOUNT_CREATION = 'false',
+    SECRET_DISABLE_IP_RESTRICTION = 'false',
+    SECRET_DISABLE_FILE_UPLOAD = 'false',
+    SECRET_RESTRICT_ORGANIZATION_EMAIL = '',
+    // Secret settings
+    SECRET_MAX_VIEWS_LIMIT = '100',
+    SECRET_ENABLE_BURN_AFTER_TIME = 'true',
+    SECRET_DISABLE_PUBLIC_SECRETS = 'false',
     NODE_ENV = 'development',
 } = process.env;
 
@@ -84,6 +95,21 @@ const config = {
         enabled: JSON.parse(SECRET_ANALYTICS_ENABLED),
         hmacSecret: SECRET_ANALYTICS_HMAC_SECRET,
     },
+    // Instance settings
+    instance: {
+        readOnly: JSON.parse(SECRET_READ_ONLY),
+        disableUsers: JSON.parse(SECRET_DISABLE_USERS),
+        disableUserAccountCreation: JSON.parse(SECRET_DISABLE_USER_ACCOUNT_CREATION),
+        disableIpRestriction: JSON.parse(SECRET_DISABLE_IP_RESTRICTION),
+        disableFileUpload: JSON.parse(SECRET_DISABLE_FILE_UPLOAD),
+        restrictOrganizationEmail: SECRET_RESTRICT_ORGANIZATION_EMAIL,
+    },
+    // Secret settings
+    secret: {
+        maxViewsLimit: Number(SECRET_MAX_VIEWS_LIMIT),
+        enableBurnAfterTime: JSON.parse(SECRET_ENABLE_BURN_AFTER_TIME),
+        disablePublicSecrets: JSON.parse(SECRET_DISABLE_PUBLIC_SECRETS),
+    },
     logger: true,
     cors: '*',
     __client_config: {
@@ -96,6 +122,11 @@ const config = {
             analytics: {
                 enabled: JSON.parse(SECRET_ANALYTICS_ENABLED),
             },
+        },
+        secret: {
+            maxViewsLimit: Number(SECRET_MAX_VIEWS_LIMIT),
+            enableBurnAfterTime: JSON.parse(SECRET_ENABLE_BURN_AFTER_TIME),
+            disablePublicSecrets: JSON.parse(SECRET_DISABLE_PUBLIC_SECRETS),
         },
     },
 };

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3.8'
 
 services:
     hemmelig:
-        image: ghcr.io/nerajchand/hemmelig:latest
+        image: hemmelig:latest
         hostname: hemmelig
         init: true
         volumes:
@@ -12,7 +12,7 @@ services:
         environment:
             - SECRET_LOCAL_HOSTNAME=0.0.0.0 # The local hostname for the fastify instance
             - SECRET_PORT=3000 # The port number for the fastify instance
-            - SECRET_HOST=!changeme! # Used for i.e. set cors/cookies to your domain name
+            - SECRET_HOST=localhost # Used for i.e. set cors/cookies to your domain name
             - SECRET_ROOT_USER=groot # User as the root admin user
             - SECRET_ROOT_PASSWORD=iamroot # The admin user password (change this after signed in)
             - SECRET_ROOT_EMAIL=groot@hemmelig.app # The email for the admin user
@@ -20,7 +20,19 @@ services:
             - SECRET_FORCED_LANGUAGE=en # Set the default language for the application
             - SECRET_JWT_SECRET=!changeme! # Override this for the secret signin JWT tokens for log in
             - SECRET_MAX_TEXT_SIZE=256 # The max text size for the secret. Is set in kb. i.e. 256 for 256kb
+            - SECRET_ANALYTICS_ENABLED=true
             - DATABASE_URL=postgresql://hemmelig:hemmelig@postgres:5432/hemmelig # Prisma connection string
+            # Instance settings (all default to "false" if not set)
+            # - SECRET_READ_ONLY=true # Enable read-only mode
+            # - SECRET_DISABLE_USERS=true # Disable user functionality
+            # - SECRET_DISABLE_USER_ACCOUNT_CREATION=true # Disable user registration
+            # - SECRET_DISABLE_IP_RESTRICTION=true # Disable IP restriction feature
+            # - SECRET_DISABLE_FILE_UPLOAD=true # Disable file uploads
+            # - SECRET_RESTRICT_ORGANIZATION_EMAIL=example.com,company.com # Comma-separated email domains
+            # Secret settings
+            - SECRET_MAX_VIEWS_LIMIT=20 # Maximum allowed views for secrets
+            # - SECRET_ENABLE_BURN_AFTER_TIME=true # Enable burn after time expires feature
+            # - SECRET_DISABLE_PUBLIC_SECRETS=true # Disable public secrets feature
         ports:
             - '3000:3000'
         restart: always

--- a/server/controllers/analytics.js
+++ b/server/controllers/analytics.js
@@ -181,12 +181,12 @@ async function analytics(fastify) {
 
                 const rawData = await prisma.$queryRaw`
                     SELECT 
-                        strftime('%Y-%m-%d', "timestamp" / 1000, 'unixepoch') as date,
+                        TO_CHAR("timestamp", 'YYYY-MM-DD') as date,
                         COUNT(DISTINCT "uniqueId") as unique_visitors,
                         COUNT(*) as total_visits,
-                        GROUP_CONCAT(DISTINCT path) as paths
+                        STRING_AGG(DISTINCT path, ', ') as paths
                     FROM "VisitorAnalytics"
-                    GROUP BY strftime('%Y-%m-%d', "timestamp" / 1000, 'unixepoch')
+                    GROUP BY TO_CHAR("timestamp", 'YYYY-MM-DD')
                     ORDER BY date DESC
                     LIMIT 30
                 `;


### PR DESCRIPTION
- Add environment variables for instance settings (read-only, disable users, disable user account creation, disable IP restriction, disable file upload)
- Add support for comma-separated email domains in organization email restriction
- Add configurable max views limit (default: 100) via `SECRET_MAX_VIEWS_LIMIT`
- Add `SECRET_ENABLE_BURN_AFTER_TIME` to control burn after expiration feature
- Add `SECRET_DISABLE_PUBLIC_SECRETS` to disable public secrets feature
- Update bootstrap to apply environment variables on startup
- Fix analytics SQL query for PostgreSQL compatibility (was using SQLite syntax)
- Fix analytics API calls to include authentication credentials
- Format password API expiresAt timestamps in Australia/Sydney timezone
- Add preventBurn parameter support to password generation API
- Update UI to conditionally show/hide features based on configuration
- Update README with new environment variables documentation