### PR TITLE
feat: Add API endpoint for password encryption

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,6 +256,69 @@ curl "https://your-instance.com/api/password/generate?length=20&numbers=true&sym
 - Secrets are deleted after reaching `maxViews` limit
 - The password is only returned in the response if `showPassword: true` is set
 
+## Secret Encryption API
+
+Hemmelig provides a REST API endpoint for encrypting secrets/passwords and automatically creating shareable secret links. This is useful when you already have a secret/password that you want to encrypt and share securely.
+
+### Endpoints
+
+- **POST** `/api/encrypt` - Encrypt secret with JSON request body
+- **GET** `/api/encrypt` - Encrypt secret with query parameters
+
+### POST Request Example
+
+```bash
+curl -X POST https://your-instance.com/api/encrypt \
+  -H "Content-Type: application/json" \
+  -d '{
+    "password": "my-secret-password",
+    "ttl": 3600,
+    "maxViews": 1,
+    "title": "My Encrypted Secret",
+    "preventBurn": false
+  }'
+```
+
+**Response:**
+```json
+{
+  "url": "https://your-instance.com/secret/abc123#encryptionkey",
+  "secretId": "abc123",
+  "expiresAt": "2024-01-02T00:00:00.000Z"
+}
+```
+
+### GET Request Example
+
+```bash
+curl "https://your-instance.com/api/encrypt?password=my-secret-password&ttl=3600&maxViews=1&title=My%20Secret"
+```
+
+### Configuration Options
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `password` | string | **Required** | The secret/password to encrypt (in plain text) |
+| `ttl` | integer | `86400` | Secret lifetime in seconds (1 day). Must be a valid TTL value |
+| `maxViews` | integer | `1` | Maximum views before secret is deleted (min: 1, max: 999) |
+| `title` | string | - | Optional title for the secret (max: 255 characters) |
+| `preventBurn` | boolean | `false` | Prevent secret from being deleted after expiration (only if feature enabled) |
+
+### Use Cases
+
+- **Encrypting existing passwords** for secure sharing
+- **CI/CD pipelines** that need to securely share pre-existing credentials
+- **Scripts** that need to encrypt and share secrets programmatically
+- **Integration** with other tools that need to encrypt secrets on-the-fly
+
+### Security Notes
+
+- The provided password/secret is encrypted before being stored
+- The decryption key is only included in the URL fragment (never sent to server)
+- Secrets automatically expire based on the `ttl` parameter
+- Secrets are deleted after reaching `maxViews` limit
+- The plain text password is never returned in the response for security
+
 ## Environment variables
 
 | ENV Variable                         | Description                                                  | Default              |

--- a/client/routes/api-docs/index.jsx
+++ b/client/routes/api-docs/index.jsx
@@ -451,6 +451,96 @@ const ApiDocs = () => {
                         </div>
                     </div>
 
+                    {/* Secret Encryption Endpoints */}
+                    <div className="bg-gray-800/50 rounded-lg p-4">
+                        <h3 className="text-lg font-medium text-white mb-4">Secret Encryption</h3>
+                        <div className="space-y-6">
+                            <div className="space-y-3">
+                                <div>
+                                    <span className="inline-block px-2 py-1 text-sm font-medium bg-green-500/20 text-green-400 rounded">
+                                        POST
+                                    </span>
+                                    <span className="ml-2 text-gray-300">/api/encrypt</span>
+                                </div>
+                                <p className="text-gray-300 text-sm">
+                                    Encrypt a provided secret/password, create a secret, and return
+                                    a shareable URL (useful when you already have a secret to
+                                    encrypt)
+                                </p>
+                                <pre className="bg-gray-900/50 p-3 rounded-md text-gray-300 overflow-x-auto">
+                                    <code>
+                                        {JSON.stringify(
+                                            {
+                                                password: 'my-secret-password',
+                                                ttl: 86400,
+                                                maxViews: 1,
+                                                title: 'My Encrypted Secret',
+                                                preventBurn: false,
+                                            },
+                                            null,
+                                            2
+                                        )}
+                                    </code>
+                                </pre>
+                                <p className="text-gray-400 text-xs mt-2">
+                                    The <code className="text-gray-300">password</code> field is
+                                    required and must be a non-empty string. All other fields are
+                                    optional. Defaults: ttl=86400 (1 day), maxViews=1,
+                                    preventBurn=false.
+                                </p>
+                                <p className="text-gray-400 text-xs mt-2">Example response:</p>
+                                <pre className="bg-gray-900/50 p-3 rounded-md text-gray-300 overflow-x-auto">
+                                    <code>
+                                        {JSON.stringify(
+                                            {
+                                                url: 'https://secret.local/secret/abc123#encryptionkey',
+                                                secretId: 'abc123',
+                                                expiresAt: '2024-01-02T00:00:00.000Z',
+                                            },
+                                            null,
+                                            2
+                                        )}
+                                    </code>
+                                </pre>
+                                <p className="text-gray-400 text-xs mt-2">
+                                    Note: The plain text password is never returned in the response
+                                    for security. The returned URL can be shared with anyone to
+                                    retrieve the secret through the web app.
+                                </p>
+                            </div>
+
+                            <div className="space-y-3">
+                                <div>
+                                    <span className="inline-block px-2 py-1 text-sm font-medium bg-blue-500/20 text-blue-400 rounded">
+                                        GET
+                                    </span>
+                                    <span className="ml-2 text-gray-300">
+                                        /api/encrypt?password=my-secret&ttl=3600&maxViews=1
+                                    </span>
+                                </div>
+                                <p className="text-gray-300 text-sm">
+                                    Encrypt a secret and create a shareable link using query
+                                    parameters (convenient for simple GET requests)
+                                </p>
+                                <pre className="bg-gray-900/50 p-3 rounded-md text-gray-300 overflow-x-auto">
+                                    <code>
+                                        {`GET /api/encrypt?password=my-secret-password&ttl=3600&maxViews=1&title=My%20Secret`}
+                                    </code>
+                                </pre>
+                                <p className="text-gray-400 text-xs mt-2">
+                                    The <code className="text-gray-300">password</code> query
+                                    parameter is required. The returned URL can be shared with
+                                    anyone to retrieve the secret through the web app.
+                                </p>
+                                <p className="text-yellow-400 text-xs mt-2">
+                                    ⚠️ Security Note: For sensitive data, prefer using POST instead
+                                    of GET, as GET parameters may appear in server logs and browser
+                                    history.
+                                </p>
+                            </div>
+                        </div>
+                    </div>
+
                     {/* Admin Endpoints */}
                     <div className="bg-gray-800/50 rounded-lg p-4">
                         <h3 className="text-lg font-medium text-white mb-4">

--- a/server.js
+++ b/server.js
@@ -29,6 +29,7 @@ import usersRoute from './server/controllers/admin/users.js';
 import analyticsRoute from './server/controllers/analytics.js';
 import authenticationRoute from './server/controllers/authentication.js';
 import downloadRoute from './server/controllers/download.js';
+import encryptRoute from './server/controllers/encrypt.js';
 import healthzRoute from './server/controllers/healthz.js';
 import passwordRoute from './server/controllers/password.js';
 import secretRoute from './server/controllers/secret.js';
@@ -174,6 +175,7 @@ fastify.register(adminSettingsRoute, {
 });
 
 fastify.register(downloadRoute, { prefix: '/api/download' });
+fastify.register(encryptRoute, { prefix: '/api/encrypt' });
 fastify.register(secretRoute, { prefix: '/api/secret' });
 fastify.register(passwordRoute, { prefix: '/api/password' });
 fastify.register(statsRoute, { prefix: '/api/stats' });

--- a/server/controllers/encrypt.js
+++ b/server/controllers/encrypt.js
@@ -1,0 +1,397 @@
+import config from 'config';
+import { encrypt, generateKey } from '../../shared/helpers/crypto.js';
+import VALID_TTL from '../helpers/validate-ttl.js';
+import prisma from '../services/prisma.js';
+
+const DEFAULT_EXPIRATION = 60 * 60 * 24 * 1000; // 1 day in milliseconds
+
+// Format date to Australia/Sydney timezone in ISO format
+function formatDateToSydney(date) {
+    // Use Intl.DateTimeFormat to get the date parts in Sydney timezone
+    const formatter = new Intl.DateTimeFormat('en-AU', {
+        timeZone: 'Australia/Sydney',
+        year: 'numeric',
+        month: '2-digit',
+        day: '2-digit',
+        hour: '2-digit',
+        minute: '2-digit',
+        second: '2-digit',
+        hour12: false,
+    });
+
+    const parts = formatter.formatToParts(date);
+    const year = parts.find((p) => p.type === 'year').value;
+    const month = parts.find((p) => p.type === 'month').value;
+    const day = parts.find((p) => p.type === 'day').value;
+    const hour = parts.find((p) => p.type === 'hour').value;
+    const minute = parts.find((p) => p.type === 'minute').value;
+    const second = parts.find((p) => p.type === 'second').value;
+
+    // Get timezone offset for Sydney at this specific date/time
+    const sydneyDate = new Date(date.toLocaleString('en-US', { timeZone: 'Australia/Sydney' }));
+    const utcDate = new Date(date.toLocaleString('en-US', { timeZone: 'UTC' }));
+    const offsetMs = sydneyDate.getTime() - utcDate.getTime();
+    const offsetMinutes = Math.round(offsetMs / (1000 * 60));
+    const offsetHours = Math.floor(Math.abs(offsetMinutes) / 60);
+    const offsetMins = Math.abs(offsetMinutes) % 60;
+    const offsetSign = offsetMinutes >= 0 ? '+' : '-';
+    const offsetString = `${offsetSign}${String(offsetHours).padStart(2, '0')}:${String(offsetMins).padStart(2, '0')}`;
+
+    return `${year}-${month}-${day}T${hour}:${minute}:${second}${offsetString}`;
+}
+
+/**
+ * Secret Encryption API Controller
+ *
+ * Provides endpoints for encrypting secrets and creating shareable secret links
+ * for automation purposes. Similar to the password generation API, but accepts
+ * a plain text password/secret to encrypt.
+ */
+async function encryptSecret(fastify) {
+    /**
+     * POST /api/encrypt
+     *
+     * Encrypt a provided secret/password, create a secret, and return a shareable URL
+     *
+     * Request body:
+     * {
+     *   "password": "my-secret-password", // Required: The secret/password to encrypt (in plain text)
+     *   "ttl": 86400,                      // Optional: Secret lifetime in seconds (default: 86400 = 1 day)
+     *   "maxViews": 1,                     // Optional: Maximum views before secret is deleted (default: 1)
+     *   "preventBurn": false,              // Optional: Prevent secret from being deleted after expiration (default: false, only if feature enabled)
+     *   "title": "My Secret"              // Optional: Title for the secret (max: 255 characters)
+     * }
+     *
+     * Response:
+     * {
+     *   "url": "https://hemmelig.app/secret/abc123#encryptionkey",
+     *   "secretId": "abc123",
+     *   "expiresAt": "2024-01-02T00:00:00.000Z"
+     * }
+     */
+    fastify.post(
+        '/',
+        {
+            schema: {
+                body: {
+                    type: 'object',
+                    required: ['password'],
+                    properties: {
+                        password: {
+                            type: 'string',
+                            minLength: 1,
+                        },
+                        ttl: {
+                            type: 'integer',
+                            minimum: 1,
+                            enum: VALID_TTL,
+                            default: 86400,
+                        },
+                        maxViews: {
+                            type: 'integer',
+                            minimum: 1,
+                            maximum: config.get('secret.maxViewsLimit'),
+                            default: 1,
+                        },
+                        preventBurn: {
+                            type: 'boolean',
+                            default: false,
+                        },
+                        title: {
+                            type: 'string',
+                            maxLength: 255,
+                        },
+                    },
+                },
+            },
+        },
+        async (request, reply) => {
+            const {
+                password,
+                ttl = 86400,
+                maxViews = 1,
+                preventBurn = false,
+                title,
+            } = request.body;
+
+            // Validate password is provided and not empty
+            if (!password || typeof password !== 'string' || password.trim().length === 0) {
+                return reply.code(400).send({
+                    error: 'Password is required and must be a non-empty string',
+                });
+            }
+
+            // Validate maxViews
+            const maxViewsNum = parseInt(maxViews, 10);
+            const maxViewsLimit = config.get('secret.maxViewsLimit');
+            if (isNaN(maxViewsNum) || maxViewsNum < 1 || maxViewsNum > maxViewsLimit) {
+                return reply.code(400).send({
+                    error: `maxViews must be a number between 1 and ${maxViewsLimit}`,
+                });
+            }
+
+            // Validate preventBurn is only used if feature is enabled
+            const enableBurnAfterTime = config.get('secret.enableBurnAfterTime');
+            if (!enableBurnAfterTime && preventBurn === false) {
+                return reply.code(400).send({
+                    error: 'Burn after time feature is disabled for this instance',
+                });
+            }
+
+            // If feature is disabled, force preventBurn to true
+            const finalPreventBurn = enableBurnAfterTime ? preventBurn : true;
+
+            try {
+                // Generate encryption key
+                const encryptionKey = generateKey();
+
+                // Encrypt the password/secret
+                const encryptedPassword = encrypt(password, encryptionKey);
+
+                // Encrypt the title if provided
+                const encryptedTitle = title ? encrypt(title, encryptionKey) : undefined;
+
+                // Create the secret
+                const secret = await prisma.secret.create({
+                    data: {
+                        title: encryptedTitle,
+                        maxViews: maxViewsNum,
+                        preventBurn: finalPreventBurn,
+                        data: encryptedPassword,
+                        user_id: request?.user?.user_id ?? null,
+                        expiresAt: new Date(
+                            Date.now() + (parseInt(ttl) ? parseInt(ttl) * 1000 : DEFAULT_EXPIRATION)
+                        ),
+                        ipAddress: '',
+                    },
+                });
+
+                // Update statistics
+                await prisma.statistic.upsert({
+                    where: {
+                        id: 'secrets_created',
+                    },
+                    update: {
+                        value: {
+                            increment: 1,
+                        },
+                    },
+                    create: { id: 'secrets_created' },
+                });
+
+                // Build the shareable URL
+                // Use request host if SECRET_HOST is not set or is a placeholder
+                const hostConfig = config.get('host');
+                let baseUrl;
+
+                if (
+                    !hostConfig ||
+                    hostConfig === 'localhost' ||
+                    hostConfig === '!changeme!' ||
+                    hostConfig.includes('changeme')
+                ) {
+                    // Use the request host from headers
+                    // Check for protocol from forwarded headers or connection
+                    const forwardedProto = request.headers['x-forwarded-proto'];
+                    const isSecure =
+                        request.secure ||
+                        request.headers['x-forwarded-ssl'] === 'on' ||
+                        forwardedProto === 'https';
+                    const protocol = forwardedProto || (isSecure ? 'https' : 'http');
+                    const host = request.headers.host || request.hostname || 'localhost:3000';
+                    baseUrl = `${protocol}://${host}`;
+                } else if (hostConfig.startsWith('http')) {
+                    baseUrl = hostConfig;
+                } else {
+                    baseUrl = `https://${hostConfig}`;
+                }
+
+                const encryptionKeyBase64 = Buffer.from(encryptionKey).toString('base64');
+                const shareableUrl = `${baseUrl}/secret/${secret.id}#${encryptionKeyBase64}`;
+
+                const response = {
+                    url: shareableUrl,
+                    secretId: secret.id,
+                    expiresAt: formatDateToSydney(secret.expiresAt),
+                };
+
+                return reply.code(200).send(response);
+            } catch (error) {
+                fastify.log.error(error);
+                return reply.code(500).send({
+                    error: 'Failed to encrypt secret and create shareable link',
+                    message: error.message,
+                });
+            }
+        }
+    );
+
+    /**
+     * GET /api/encrypt
+     *
+     * Encrypt a secret and create a shareable link with query parameters
+     *
+     * Query parameters:
+     * - password: The secret/password to encrypt (required)
+     * - ttl: Secret lifetime in seconds (default: 86400)
+     * - maxViews: Maximum views (default: 1)
+     * - preventBurn: Prevent burn after expiration (default: false)
+     */
+    fastify.get(
+        '/',
+        {
+            schema: {
+                querystring: {
+                    type: 'object',
+                    required: ['password'],
+                    properties: {
+                        password: {
+                            type: 'string',
+                        },
+                        ttl: {
+                            type: 'string',
+                            pattern: '^\\d+$',
+                        },
+                        maxViews: {
+                            type: 'string',
+                            pattern: '^\\d+$',
+                        },
+                        preventBurn: {
+                            type: 'string',
+                            enum: ['true', 'false'],
+                        },
+                        title: {
+                            type: 'string',
+                        },
+                    },
+                },
+            },
+        },
+        async (request, reply) => {
+            const {
+                password,
+                ttl = '86400',
+                maxViews = '1',
+                preventBurn = 'false',
+                title,
+            } = request.query;
+
+            // Validate password is provided
+            if (!password || typeof password !== 'string' || password.trim().length === 0) {
+                return reply.code(400).send({
+                    error: 'Password is required and must be a non-empty string',
+                });
+            }
+
+            const ttlNum = parseInt(ttl, 10);
+            if (!VALID_TTL.includes(ttlNum)) {
+                return reply.code(400).send({
+                    error: `TTL must be one of: ${VALID_TTL.join(', ')}`,
+                });
+            }
+
+            const maxViewsNum = parseInt(maxViews, 10);
+            const maxViewsLimit = config.get('secret.maxViewsLimit');
+            if (isNaN(maxViewsNum) || maxViewsNum < 1 || maxViewsNum > maxViewsLimit) {
+                return reply.code(400).send({
+                    error: `maxViews must be a number between 1 and ${maxViewsLimit}`,
+                });
+            }
+
+            // Validate preventBurn is only used if feature is enabled
+            const enableBurnAfterTime = config.get('secret.enableBurnAfterTime');
+            const preventBurnBool = preventBurn === 'true';
+            if (!enableBurnAfterTime && !preventBurnBool) {
+                return reply.code(400).send({
+                    error: 'Burn after time feature is disabled for this instance',
+                });
+            }
+
+            // If feature is disabled, force preventBurn to true
+            const finalPreventBurn = enableBurnAfterTime ? preventBurnBool : true;
+
+            try {
+                // Generate encryption key
+                const encryptionKey = generateKey();
+
+                // Encrypt the password/secret
+                const encryptedPassword = encrypt(password, encryptionKey);
+
+                // Encrypt the title if provided
+                const encryptedTitle = title ? encrypt(title, encryptionKey) : undefined;
+
+                // Create the secret
+                const secret = await prisma.secret.create({
+                    data: {
+                        title: encryptedTitle,
+                        maxViews: maxViewsNum,
+                        preventBurn: finalPreventBurn,
+                        data: encryptedPassword,
+                        user_id: request?.user?.user_id ?? null,
+                        expiresAt: new Date(Date.now() + ttlNum * 1000),
+                        ipAddress: '',
+                    },
+                });
+
+                // Update statistics
+                await prisma.statistic.upsert({
+                    where: {
+                        id: 'secrets_created',
+                    },
+                    update: {
+                        value: {
+                            increment: 1,
+                        },
+                    },
+                    create: { id: 'secrets_created' },
+                });
+
+                // Build the shareable URL
+                // Use request host if SECRET_HOST is not set or is a placeholder
+                const hostConfig = config.get('host');
+                let baseUrl;
+
+                if (
+                    !hostConfig ||
+                    hostConfig === 'localhost' ||
+                    hostConfig === '!changeme!' ||
+                    hostConfig.includes('changeme')
+                ) {
+                    // Use the request host from headers
+                    // Check for protocol from forwarded headers or connection
+                    const forwardedProto = request.headers['x-forwarded-proto'];
+                    const isSecure =
+                        request.secure ||
+                        request.headers['x-forwarded-ssl'] === 'on' ||
+                        forwardedProto === 'https';
+                    const protocol = forwardedProto || (isSecure ? 'https' : 'http');
+                    const host = request.headers.host || request.hostname || 'localhost:3000';
+                    baseUrl = `${protocol}://${host}`;
+                } else if (hostConfig.startsWith('http')) {
+                    baseUrl = hostConfig;
+                } else {
+                    baseUrl = `https://${hostConfig}`;
+                }
+
+                const encryptionKeyBase64 = Buffer.from(encryptionKey).toString('base64');
+                const shareableUrl = `${baseUrl}/secret/${secret.id}#${encryptionKeyBase64}`;
+
+                const response = {
+                    url: shareableUrl,
+                    secretId: secret.id,
+                    expiresAt: formatDateToSydney(secret.expiresAt),
+                };
+
+                return reply.code(200).send(response);
+            } catch (error) {
+                fastify.log.error(error);
+                return reply.code(500).send({
+                    error: 'Failed to encrypt secret and create shareable link',
+                    message: error.message,
+                });
+            }
+        }
+    );
+}
+
+export default encryptSecret;


### PR DESCRIPTION
Add new endpoint that accepts a plain text password/secret and creates a sharable encrypted secret link. Similar to the password generation API but for encrypting existing secrets rather than generating a new secret.

Documentation and README has also been updated with information on how this new API can be used.