### PR TITLE
feat: Add var to enable advanced copy

### DIFF
--- a/README.md
+++ b/README.md
@@ -333,7 +333,7 @@ curl "https://your-instance.com/api/encrypt?password=my-secret-password&ttl=3600
 | `SECRET_ROOT_EMAIL`                   | Root account email                                           | `groot@hemmelig.app` |
 | `SECRET_FILE_SIZE`                    | Max upload file size (in MB)                                 | `4`                  |
 | `SECRET_FORCED_LANGUAGE`              | Default language for the application                         | `en`                 |
-| `SECRET_UPLOAD_RESTRICTION`           | Restrict uploads to signed-in users ("true"/"false")         | `"true"`             |
+| `SECRET_UPLOAD_RESTRICTION`           | Restrict uploads to signed-in users                          | `"true"`             |
 | `SECRET_RATE_LIMIT_MAX`               | Max requests per rate limit window                           | `1000`               |
 | `SECRET_RATE_LIMIT_TIME_WINDOW`       | Rate limit time window (seconds)                             | `60`                 |
 | `SECRET_DO_SPACES_ENDPOINT`           | DigitalOcean Spaces/S3 endpoint                              | `""`                 |
@@ -346,8 +346,9 @@ curl "https://your-instance.com/api/encrypt?password=my-secret-password&ttl=3600
 | `SECRET_AWS_S3_SECRET`                | AWS S3 secret key                                            | `""`                 |
 | `SECRET_AWS_S3_BUCKET`                | AWS S3 bucket name                                           | `""`                 |
 | `SECRET_AWS_S3_FOLDER`                | AWS S3 folder for uploads                                    | `""`                 |
-| `SECRET_ANALYTICS_ENABLED`            | Enable analytics tracking ("true"/"false")                   | `"false"`            |
+| `SECRET_ANALYTICS_ENABLED`            | Enable analytics tracking                                    | `"false"`            |
 | `SECRET_ANALYTICS_HMAC_SECRET`        | HMAC secret for analytics tracking                           | `"1234567890"`       |
+| `SECRET_ADVANCED_COPY`                | Show advanced copy options (HTML & Base64)                   | `"false"`            |
 | `SECRET_READ_ONLY`                    | Read-only mode (only admin/creator can create secrets)       | `"false"`            |
 | `SECRET_DISABLE_USERS`                | Disable user functionality                                   | `"false"`            |
 | `SECRET_DISABLE_USER_ACCOUNT_CREATION`| Disable user account registration                            | `"false"`            |

--- a/client/components/editor/index.jsx
+++ b/client/components/editor/index.jsx
@@ -30,6 +30,7 @@ import StarterKit from '@tiptap/starter-kit';
 import { generate } from 'generate-password-browser';
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
+import config from '../../config';
 
 const generatePassword = (
     length = 16,
@@ -333,7 +334,7 @@ const ReadOnlyMenuBar = () => {
         navigator.clipboard
             .writeText(text)
             .then(() => {
-                setCopySuccess(t('editor.copy_success.text'));
+                setCopySuccess(t('editor.copy_success.copied'));
                 setTimeout(() => setCopySuccess(''), 2000);
             })
             .catch((err) => {
@@ -361,33 +362,52 @@ const ReadOnlyMenuBar = () => {
     };
 
     const buttonClass =
+        'flex items-center gap-2 px-3 py-2 text-sm rounded-md bg-gray-700 hover:bg-gray-600 text-gray-200 transition-colors';
+    const iconButtonClass =
         'p-1.5 text-sm rounded-md hover:bg-gray-700 text-gray-200 transition-colors';
     const groupClass = 'flex items-center border border-gray-700 rounded-md bg-gray-800 shadow-sm';
 
+    // Check if advanced copy features are enabled
+    const showAdvancedCopy = config.get('editor.advancedCopy', false);
+
     return (
-        <div className="mb-4 flex w-full">
-            <div className="flex gap-2">
-                <div className={groupClass}>
-                    <Tooltip text={t('editor.tooltips.copy_text')}>
-                        <button onClick={copyAsPlainText} className={buttonClass}>
-                            <IconCopy size={20} stroke={1.5} className="text-gray-300" />
-                        </button>
-                    </Tooltip>
-                    <Tooltip text={t('editor.tooltips.copy_html')}>
-                        <button onClick={copyAsHTML} className={buttonClass}>
-                            <IconSourceCode size={20} className="text-gray-300" />
-                        </button>
-                    </Tooltip>
-                    <Tooltip text={t('editor.tooltips.copy_base64')}>
-                        <button onClick={copyAsBase64} className={buttonClass}>
-                            <IconNumber64Small size={20} stroke={1.5} className="text-gray-300" />
-                        </button>
-                    </Tooltip>
-                </div>
+        <div className="mb-4 flex w-full justify-end">
+            <div className="flex items-center gap-2">
+                {copySuccess && (
+                    <div className="text-sm text-gray-200 animate-fade-in-out">{copySuccess}</div>
+                )}
+
+                {showAdvancedCopy ? (
+                    // Advanced mode: Show all copy options in a grouped style
+                    <div className={groupClass}>
+                        <Tooltip text={t('editor.tooltips.copy_text')}>
+                            <button onClick={copyAsPlainText} className={iconButtonClass}>
+                                <IconCopy size={16} stroke={1.5} className="text-gray-300" />
+                            </button>
+                        </Tooltip>
+                        <Tooltip text={t('editor.tooltips.copy_html')}>
+                            <button onClick={copyAsHTML} className={iconButtonClass}>
+                                <IconSourceCode size={16} className="text-gray-300" />
+                            </button>
+                        </Tooltip>
+                        <Tooltip text={t('editor.tooltips.copy_base64')}>
+                            <button onClick={copyAsBase64} className={iconButtonClass}>
+                                <IconNumber64Small
+                                    size={16}
+                                    stroke={1.5}
+                                    className="text-gray-300"
+                                />
+                            </button>
+                        </Tooltip>
+                    </div>
+                ) : (
+                    // Simple mode: Show only the main copy button with text
+                    <button onClick={copyAsPlainText} className={buttonClass}>
+                        <IconCopy size={16} stroke={1.5} className="text-gray-300" />
+                        <span>{t('editor.copy')}</span>
+                    </button>
+                )}
             </div>
-            {copySuccess && (
-                <div className="text-sm text-gray-200 animate-fade-in-out p-2">{copySuccess}</div>
-            )}
         </div>
     );
 };

--- a/config/default.cjs
+++ b/config/default.cjs
@@ -24,6 +24,8 @@ const {
     SECRET_RATE_LIMIT_TIME_WINDOW = 60,
     SECRET_ANALYTICS_ENABLED = 'true',
     SECRET_ANALYTICS_HMAC_SECRET = '1234567890',
+    // Editor settings
+    SECRET_ADVANCED_COPY = 'false',
     // Instance settings defaults
     SECRET_READ_ONLY = 'false',
     SECRET_DISABLE_USERS = 'false',
@@ -95,6 +97,10 @@ const config = {
         enabled: JSON.parse(SECRET_ANALYTICS_ENABLED),
         hmacSecret: SECRET_ANALYTICS_HMAC_SECRET,
     },
+    // Editor settings
+    editor: {
+        advancedCopy: JSON.parse(SECRET_ADVANCED_COPY),
+    },
     // Instance settings
     instance: {
         readOnly: JSON.parse(SECRET_READ_ONLY),
@@ -127,6 +133,9 @@ const config = {
             maxViewsLimit: Number(SECRET_MAX_VIEWS_LIMIT),
             enableBurnAfterTime: JSON.parse(SECRET_ENABLE_BURN_AFTER_TIME),
             disablePublicSecrets: JSON.parse(SECRET_DISABLE_PUBLIC_SECRETS),
+        },
+        editor: {
+            advancedCopy: JSON.parse(SECRET_ADVANCED_COPY),
         },
     },
 };

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,4 @@
-version: '3.8'
-
+---
 services:
     hemmelig:
         image: hemmelig:latest
@@ -22,6 +21,8 @@ services:
             - SECRET_MAX_TEXT_SIZE=256 # The max text size for the secret. Is set in kb. i.e. 256 for 256kb
             - SECRET_ANALYTICS_ENABLED=true
             - DATABASE_URL=postgresql://hemmelig:hemmelig@postgres:5432/hemmelig # Prisma connection string
+            # Editor settings
+            # - SECRET_ADVANCED_COPY=true # Enable advanced copy options (HTML & Base64)
             # Instance settings (all default to "false" if not set)
             # - SECRET_READ_ONLY=true # Enable read-only mode
             # - SECRET_DISABLE_USERS=true # Disable user functionality

--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -320,10 +320,12 @@
             "cancel": "Cancel",
             "insert": "Insert"
         },
+        "copy": "Copy",
         "copy_success": {
             "html": "HTML copied!",
             "text": "Plain text copied!",
-            "base64": "Base64 copied!"
+            "base64": "Base64 copied!",
+            "copied": "Copied!"
         }
     }
 }


### PR DESCRIPTION
In most cases, users won't be copying the exposed password in HTML or base64, and as such these options are not really needed. As a way around this, we're enabling a environment variable to control this - `SECRET_ADVANCED_COPY` - this value is set to `false` by default which means there will be a simple "Copy" button only. IF in the future base64 or HTML is required, this can be re-enabled by the env var.