### PR TITLE
💚 fix: update gh action to allow gitmoji

### DIFF
--- a/release.config.js
+++ b/release.config.js
@@ -1,0 +1,22 @@
+module.exports = {
+    branches: ['main'],
+    plugins: [
+        [
+            '@semantic-release/commit-analyzer',
+            {
+                // Use conventionalcommits preset but relax the header parser so
+                // it tolerates leading emoji or other non-alphanumeric prefixes.
+                preset: 'conventionalcommits',
+                parserOpts: {
+                    // Match optional non-alphanumeric characters at the start (e.g. emoji),
+                    // then capture type, optional scope, and subject.
+                    headerPattern: '^[^A-Za-z0-9]*([A-Za-z]+)(?:\\(([^)]+)\\))?:\\s(.*)$',
+                    headerCorrespondence: ['type', 'scope', 'subject'],
+                },
+            },
+        ],
+        '@semantic-release/release-notes-generator',
+        '@semantic-release/npm',
+        '@semantic-release/github',
+    ],
+};


### PR DESCRIPTION
Previously if a gitmoji was added into the PR message this wouldn't trigger the semver bump correctly. This has been fixed.