### PR TITLE
fix: Remove Semantic release NPM

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,6 @@
       ],
       "@semantic-release/release-notes-generator",
       "@semantic-release/changelog",
-      "@semantic-release/npm",
       [
         "@semantic-release/github",
         {


### PR DESCRIPTION
We aren't publishing anything on NPM so this can be removed as it's blocking GH actions from running successfully.