### PR TITLE
fix: API URL Mismatch

### DIFF
--- a/client/components/header/logo.jsx
+++ b/client/components/header/logo.jsx
@@ -1,12 +1,7 @@
 import logo from '../../../logo.png';
 
 const Logo = ({ className, ...rest }) => (
-    <img
-        src={logo}
-        alt="Logo"
-        className={`w-[45px] h-auto ${className}`}
-        {...rest}
-    />
+    <img src={logo} alt="Logo" className={`w-[45px] h-auto ${className}`} {...rest} />
 );
 
 export default Logo;

--- a/config/default.cjs
+++ b/config/default.cjs
@@ -37,6 +37,7 @@ const {
     SECRET_MAX_VIEWS_LIMIT = '100',
     SECRET_ENABLE_BURN_AFTER_TIME = 'true',
     SECRET_DISABLE_PUBLIC_SECRETS = 'false',
+    SECRET_TRUST_PROXY = 'true',
     NODE_ENV = 'development',
 } = process.env;
 
@@ -45,6 +46,7 @@ const config = {
     env: NODE_ENV,
     host: SECRET_HOST,
     port: SECRET_PORT,
+    trustProxy: JSON.parse(SECRET_TRUST_PROXY),
     upload_restriction: JSON.parse(SECRET_UPLOAD_RESTRICTION),
     rateLimit: {
         max: Number(SECRET_RATE_LIMIT_MAX),

--- a/server.js
+++ b/server.js
@@ -54,6 +54,7 @@ const staticPath = path.join(__dirname, !isDev ? 'client/build' : 'client');
 const fastify = importFastify({
     logger: config.get('logger'),
     bodyLimit: MAX_FILE_BYTES,
+    trustProxy: config.get('trustProxy'),
 });
 
 await fastify.register(FastifyVite, {

--- a/server/controllers/encrypt.js
+++ b/server/controllers/encrypt.js
@@ -180,31 +180,14 @@ async function encryptSecret(fastify) {
                 });
 
                 // Build the shareable URL
-                // Use request host if SECRET_HOST is not set or is a placeholder
-                const hostConfig = config.get('host');
-                let baseUrl;
-
-                if (
-                    !hostConfig ||
-                    hostConfig === 'localhost' ||
-                    hostConfig === '!changeme!' ||
-                    hostConfig.includes('changeme')
-                ) {
-                    // Use the request host from headers
-                    // Check for protocol from forwarded headers or connection
-                    const forwardedProto = request.headers['x-forwarded-proto'];
-                    const isSecure =
-                        request.secure ||
-                        request.headers['x-forwarded-ssl'] === 'on' ||
-                        forwardedProto === 'https';
-                    const protocol = forwardedProto || (isSecure ? 'https' : 'http');
-                    const host = request.headers.host || request.hostname || 'localhost:3000';
-                    baseUrl = `${protocol}://${host}`;
-                } else if (hostConfig.startsWith('http')) {
-                    baseUrl = hostConfig;
-                } else {
-                    baseUrl = `https://${hostConfig}`;
-                }
+                const forwardedProto = request.headers['x-forwarded-proto'];
+                const isSecure =
+                    request.secure ||
+                    request.headers['x-forwarded-ssl'] === 'on' ||
+                    forwardedProto === 'https';
+                const protocol = forwardedProto || (isSecure ? 'https' : 'http');
+                const host = request.headers.host || request.hostname || 'localhost:3000';
+                const baseUrl = `${protocol}://${host}`;
 
                 const encryptionKeyBase64 = Buffer.from(encryptionKey).toString('base64');
                 const shareableUrl = `${baseUrl}/secret/${secret.id}#${encryptionKeyBase64}`;
@@ -347,31 +330,14 @@ async function encryptSecret(fastify) {
                 });
 
                 // Build the shareable URL
-                // Use request host if SECRET_HOST is not set or is a placeholder
-                const hostConfig = config.get('host');
-                let baseUrl;
-
-                if (
-                    !hostConfig ||
-                    hostConfig === 'localhost' ||
-                    hostConfig === '!changeme!' ||
-                    hostConfig.includes('changeme')
-                ) {
-                    // Use the request host from headers
-                    // Check for protocol from forwarded headers or connection
-                    const forwardedProto = request.headers['x-forwarded-proto'];
-                    const isSecure =
-                        request.secure ||
-                        request.headers['x-forwarded-ssl'] === 'on' ||
-                        forwardedProto === 'https';
-                    const protocol = forwardedProto || (isSecure ? 'https' : 'http');
-                    const host = request.headers.host || request.hostname || 'localhost:3000';
-                    baseUrl = `${protocol}://${host}`;
-                } else if (hostConfig.startsWith('http')) {
-                    baseUrl = hostConfig;
-                } else {
-                    baseUrl = `https://${hostConfig}`;
-                }
+                const forwardedProto = request.headers['x-forwarded-proto'];
+                const isSecure =
+                    request.secure ||
+                    request.headers['x-forwarded-ssl'] === 'on' ||
+                    forwardedProto === 'https';
+                const protocol = forwardedProto || (isSecure ? 'https' : 'http');
+                const host = request.headers.host || request.hostname || 'localhost:3000';
+                const baseUrl = `${protocol}://${host}`;
 
                 const encryptionKeyBase64 = Buffer.from(encryptionKey).toString('base64');
                 const shareableUrl = `${baseUrl}/secret/${secret.id}#${encryptionKeyBase64}`;


### PR DESCRIPTION
We're facing an issue where when we call the API's the URL that is returned is based off the `HOST_URL` environment variable rather than the host we're curling.

This leads to a URL mismatch as we curl 1 endpoint, but the response is another.

This fix will ignore the HOST_URL variable in this case, and simply read the URL you curl and pass that on.